### PR TITLE
added reference to ghdecoy

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ gitfiti is released under [The MIT license (MIT)](http://opensource.org/licenses
 ####Notable derivatives or mentions:
 - [Pikesley's](https://github.com/pikesley) Pokrovsky, which offers Github History Vandalism [as a Service!](http://pokrovsky.herokuapp.com/)
 - [github-board](https://github.com/bayandin/github-board)
+- [ghdecoy](https://github.com/tickelton/ghdecoy)
 - Seen something else? Submit a pull request or open an issue!
 
 


### PR DESCRIPTION
My script 'ghdecoy' that fills the contribution graph with random data was originally a fork of gitfiti and still uses the template for the bash script and some other bits and pieces, so I added it to the list of derivatives in the README.