### PR TITLE
Added initial configuration file for Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+install:
+  - "pip install pytest"
+script:
+  - "py.test tests"
+sudo: false
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.5-dev"
+  - "nightly"
 install:
   - "pip install pytest"
 script:


### PR DESCRIPTION
I'm fine with either nose2 and py.test.

I usually setup nose2 as collector in `setup.py` and run it with `python setup.py test`, but the file has not landed in this repository, yet, and people like py.test a lot, so let's give it a spin.

More Python versions should work, but supporting anything lower that 2.7 and 3.4 probably isn't worth it.