### PR TITLE
Fix git pull error

### DIFF
--- a/gitfiti.py
+++ b/gitfiti.py
@@ -301,7 +301,7 @@ def fake_it(image, start_date, username, repo, git_url, offset=0, multiplier=1):
         'git add gitfiti\n'
         '{1}\n'
         'git remote add origin {2}:{3}/$REPO.git\n'
-        'git pull\n'
+        'git pull origin master\n'
         'git push -u origin master\n'
     )
 


### PR DESCRIPTION
Avoid this: 

```
+ git pull
Auto packing the repository in background for optimum performance.
See "git help gc" for manual housekeeping.
There is no tracking information for the current branch.
Please specify which branch you want to merge with.
See git-pull(1) for details.

    git pull <remote> <branch>

If you wish to set tracking information for this branch you can do so with:

    git branch --set-upstream-to=origin/<branch> master
```
