### PR TITLE
Adjust final message

### DIFF
--- a/gitfiti.py
+++ b/gitfiti.py
@@ -396,7 +396,7 @@ def main():
 
     save(output, 'gitfiti.sh')
     print('gitfiti.sh saved.')
-    print('Create a new(!) repo at {0}new and run the script'.format(git_base))
+    print('Create a new(!) repo named {0} at {1} and run the script'.format(repo, git_base))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Removes the 'new' behind the GitHub URL and adds the actual repo name to the sentence:

Old: "Create a new(!) repo at https://github.com/new and run the script"
New: "Create a new(!) repo named _reponame_ at https://github.com and run the script"