### PR TITLE
Replace "/bin/bash" with "/usr/bin/env bash"

### DIFF
--- a/gitfiti.py
+++ b/gitfiti.py
@@ -302,7 +302,7 @@ def commit(commitdate):
 
 def fake_it(image, start_date, username, repo, git_url, offset=0, multiplier=1):
     template = (
-        '#!/bin/bash\n'
+        '#!/usr/bin/env bash\n'
         'REPO={0}\n'
         'git init $REPO\n'
         'cd $REPO\n'


### PR DESCRIPTION
Improves portability, does not have any negative side effects.

On most systems, this will not change anything, since `/usr/bin/env bash` usually redirects to `/bin/bash`. On [NixOS](https://nixos.org/) (and other operating systems that do not have a `/bin/bash` file), this will allow the `env` program (practically universal) to decide which `bash` to execute.