### PR TITLE
Issue #37 : Fixed empty repo name bug 

### DIFF
--- a/gitfiti.py
+++ b/gitfiti.py
@@ -14,6 +14,9 @@ import itertools
 import json
 import math
 import os
+import random
+import string
+
 try:
     # Python 3+
     from urllib.error import HTTPError, URLError
@@ -367,6 +370,18 @@ def main():
     repo = request_user_input(
         'Enter the name of the repository to use by gitfiti: ')
 
+    if not repo.strip():
+        repo = 'gitfiti-'+''.join(random.SystemRandom().choice(string.ascii_lowercase + string.digits) for _ in range(10))
+		# Creating a repo name prefixed by "gitfiti" followed by 10 randomly generated characters.
+        print((
+			'Blank repo name is invalid'
+			))
+        
+        print((
+			'Assigning a random repo name: '+repo
+		))
+    else :
+        pass
     offset = request_user_input(
         'Enter the number of weeks to offset the image (from the left): ')
 


### PR DESCRIPTION
Issue #37 fixed.

* The user can now not enter a blank repo name.
* If a blank repo name is entered a new unique random repo name is generated and the user is notified about it.
* The new repo name is prefixed by the word "gitfiti" and then followed by a 10 character unique name.
![image](https://user-images.githubusercontent.com/24970283/49201688-e91f8a80-f3c7-11e8-8c14-f7d8dd381518.png)
