### PR TITLE
Support Powershell as target shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 gitfiti.sh
+gitfiti.ps1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An example of gitfiti in the wild:
 
 `gitfiti.py` is a tool I wrote to decorate your github account's commit history calendar by (blatantly) abusing git's ability to accept commits _in the past_.
 
-How?  `gitfiti.py` generates a bash script: `gitfiti.sh` that makes commits with the GIT_AUTHOR_DATE and GIT_COMMITTER_DATE environment variables set for each targeted pixel.
+How?  `gitfiti.py` generates a script that makes commits with the GIT_AUTHOR_DATE and GIT_COMMITTER_DATE environment variables set for each targeted pixel.
 
 Since this is likely to clobber repo's history, I highly recommend that you create a _new_ github repo when using gitfiti. Also, the generated bash script assumes you are using public-key authentication with git.
 
@@ -19,7 +19,7 @@ Included "art" from left to right: kitty, oneup, oneup2, hackerschool, octocat, 
 ### Usage:
 1. Create a new github repo to store your handiwork.
 2. Run `gitfiti.py` and follow the prompts for username, art selection, offset, and repo name.
-3. Run the generated `gitfiti.sh` from your home directory (or any non-git tracked dir) and watch it go to work.
+3. Run the generated `gitfiti.sh` or `gitfiti.ps1` from your home directory (or any non-git tracked dir) and watch it go to work.
 4. Wait... Seriously, you'll probably need to wait a day or two for the gitfiti to show in your commit graph.
 
 ### User Templates


### PR DESCRIPTION
Supporting `powershell` alongside `bash` effectively makes `gitfiti` usable on any Windows machine with Python installed.

This PR also adds code that will make it easy to add support for new target shells in the future.