### PR TITLE
Added reference to impost0r to README.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ gitfiti is released under [The MIT license (MIT)](http://opensource.org/licenses
 - [git-draw](https://github.com/ben174/git-draw) a Chrome extension which will allow you to freely draw on your commit map(!)
 - [github-jack](https://github.com/tardypad/github-jack) a pure bash version with space invaders and shining creepypasta
 - [github-graffiti](https://github.com/mavrk/github-graffiti) a GUI editor with a bash script to allow custom designs on your commit map
+- [impost0r](https://github.com/tickelton/impost0r) lets you copy another user's activity data to your calendar
 - Seen something else? Submit a pull request or open an issue!
 
 


### PR DESCRIPTION
I added a reference to [impost0r](https://github.com/tickelton/impost0r) to the README since impost0r is heavily inspired by gitfiti and a direct successor of [ghdecoy](https://github.com/tickelton/ghdecoy) which in itself was practically a fork of gitfiti.